### PR TITLE
添加“原生权限控制器”Hook

### DIFF
--- a/app/src/main/java/com/qimian233/ztool/hook/base/HookManager.java
+++ b/app/src/main/java/com/qimian233/ztool/hook/base/HookManager.java
@@ -12,6 +12,7 @@ import com.qimian233.ztool.hook.modules.packageinstaller.PackageInstallerPermiss
 import com.qimian233.ztool.hook.modules.packageinstaller.packageInstallerStyleHook;
 import com.qimian233.ztool.hook.modules.setting.AllowDisplayDolbyHook;
 import com.qimian233.ztool.hook.modules.setting.OwnerInfoHook;
+import com.qimian233.ztool.hook.modules.setting.PermissionControllerHook;
 import com.qimian233.ztool.hook.modules.setting.SplitScreenMandatory;
 import com.qimian233.ztool.hook.modules.setting.yishijiecompletion;
 import com.qimian233.ztool.hook.modules.systemui.CustomControlCenterDate;
@@ -84,6 +85,9 @@ public class HookManager {
         registerHookModule(new packageInstallerStyleHook());
         // 注册模块：允许关闭Dolby
         registerHookModule(new AllowDisplayDolbyHook());
+        // 注册模块：权限控制器样式Hook
+        registerHookModule(new PermissionControllerHook());
+
         initialized = true;
     }
 

--- a/app/src/main/java/com/qimian233/ztool/hook/modules/setting/PermissionControllerHook.java
+++ b/app/src/main/java/com/qimian233/ztool/hook/modules/setting/PermissionControllerHook.java
@@ -1,0 +1,125 @@
+package com.qimian233.ztool.hook.modules.setting;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.Window;
+
+import com.qimian233.ztool.hook.base.BaseHookModule;
+
+import java.lang.invoke.MethodHandles;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XC_MethodReplacement;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+//import xyz.cirno.unfuckzui.FeatureRegistry;
+
+public class PermissionControllerHook extends BaseHookModule {
+    public static final String FEATURE_NAME = "permission_controller_style";
+    //public static final FeatureRegistry.Feature FEATURE = new FeatureRegistry.Feature(FEATURE_NAME, new String[] {"com.android.permissioncontroller", "com.android.settings", "com.zui.safecenter"}, PermissionControllerHook::handleLoadPackage);
+    private static final String TARGET_PACKAGE = "com.android.systemui";
+    @Override
+    public String getModuleName() {
+        return "PermissionControllerHook";
+    }
+
+    @Override
+    public String[] getTargetPackages() {
+        return new String[]{"com.android.permissioncontroller", "com.android.settings", "com.zui.safecenter"};
+    }
+
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
+        if (!isEnabled()) return;
+        if ("com.android.permissioncontroller".equals(lpparam.packageName)) {
+            handleLoadPermissionController(lpparam);
+        } else if ("com.android.settings".equals(lpparam.packageName)) {
+            new SettingsHook().handleLoadSettings(lpparam);
+        } else if ("com.zui.safecenter".equals(lpparam.packageName)) {
+            handleLoadSafeCenter(lpparam);
+        }
+    }
+
+    private static void handleLoadSafeCenter(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
+        var cls = XposedHelpers.findClass("com.lenovo.xuipermissionmanager.XuiPermissionManager", lpparam.classLoader);
+        var supercls = cls.getSuperclass();
+        var onCreate = XposedHelpers.findMethodExact(cls, "onCreate", Bundle.class);
+        var super_onCreate = XposedHelpers.findMethodExact(supercls, "onCreate", Bundle.class);
+        final var super_onCreate_invokespecial = MethodHandles.lookup().unreflectSpecial(super_onCreate, cls);
+        XposedBridge.hookMethod(onCreate, new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                // redirect to AOSP permission manager
+                super_onCreate_invokespecial.invoke(param.thisObject, param.args[0]);
+                var activity = (Activity)param.thisObject;
+                activity.startActivity(new Intent("android.intent.action.MANAGE_PERMISSIONS"));
+                activity.finish();
+                param.setResult(null);
+            }
+        });
+        XposedHelpers.findAndHookMethod(cls, "onDestroy", XC_MethodReplacement.DO_NOTHING);
+    }
+
+    static class SettingsHook {
+        private final ThreadLocal<Boolean> isRowVersionTls = new ThreadLocal<>();
+
+        private class IsRowVersionHook extends XC_MethodHook {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                var value = isRowVersionTls.get();
+                if (value != null) {
+                    param.setResult(value);
+                }
+            }
+        }
+
+        private class IsRowVersionTlsHook extends XC_MethodHook {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                isRowVersionTls.set(true);
+            }
+
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                isRowVersionTls.remove();
+            }
+        }
+
+        public void handleLoadSettings(XC_LoadPackage.LoadPackageParam lpparam) {
+            XposedHelpers.findAndHookMethod("com.lenovo.common.utils.LenovoUtils", lpparam.classLoader, "isRowVersion", new IsRowVersionHook());
+
+            // make settings invoke AOSP permission manager
+            XposedHelpers.findAndHookMethod("com.android.settings.applications.appinfo.AppPermissionPreferenceController", lpparam.classLoader, "startManagePermissionsActivity", new IsRowVersionTlsHook());
+            XposedHelpers.findAndHookMethod("com.lenovo.settings.privacy.PrivacyManagerPreferenceController", lpparam.classLoader, "handlePreferenceTreeClick", "androidx.preference.Preference", new IsRowVersionTlsHook());
+            XposedHelpers.findAndHookMethod("com.lenovo.settings.applications.LenovoAppHeaderPreferenceController", lpparam.classLoader, "lambda$initAppEntryList$0$com-lenovo-settings-applications-LenovoAppHeaderPreferenceController", "android.view.View", new IsRowVersionTlsHook());
+        }
+    }
+
+    public static void handleLoadPermissionController(XC_LoadPackage.LoadPackageParam lpparam) {
+        Class<?> zuiUtilsCls = XposedHelpers.findClassIfExists("com.android.permissioncontroller.extra.ZuiUtils", lpparam.classLoader);
+        if (zuiUtilsCls == null) {
+            zuiUtilsCls = XposedHelpers.findClassIfExists("com.android.permissioncontroller.permission.utils.ZuiUtils", lpparam.classLoader);
+        }
+        if (zuiUtilsCls != null) {
+            XposedHelpers.findAndHookMethod(zuiUtilsCls, "isCTSandGTS", String.class, XC_MethodReplacement.returnConstant(Boolean.TRUE));
+        }
+        else {
+            XposedBridge.log("ZuiUtils not found");
+        }
+
+        if (Build.VERSION.SDK_INT <= 34) {
+            XposedHelpers.findAndHookMethod("com.android.permissioncontroller.permission.ui.GrantPermissionsActivity", lpparam.classLoader, "onCreate", Bundle.class, new XC_MethodHook() {
+                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                    var activity = (Activity) param.thisObject;
+                    activity.setTheme(android.R.style.Theme_DeviceDefault_Light_Dialog_Alert);
+                    activity.requestWindowFeature(Window.FEATURE_NO_TITLE);
+                    var rootView = activity.getWindow().getDecorView();
+                    rootView.setFilterTouchesWhenObscured(true);
+                    rootView.setPadding(0, 0, 0, 0);
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_settings_detail.xml
+++ b/app/src/main/res/layout/activity_settings_detail.xml
@@ -466,7 +466,7 @@
                             android:textColor="?attr/colorOnSurface"
                             android:layout_marginBottom="16dp" />
 
-                        <!-- 导入字体选项 - 整个项目可点击，带有涟漪效果 -->
+                        <!-- Dolby选项 - 整个项目可点击，带有涟漪效果 -->
                         <LinearLayout
                             android:id="@+id/DolbyLinearLayout"
                             android:layout_width="match_parent"
@@ -506,6 +506,79 @@
                                 android:layout_height="wrap_content" />
 
                         </LinearLayout>
+
+
+
+                    </LinearLayout>
+
+                </androidx.cardview.widget.CardView>
+
+                <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    app:cardCornerRadius="16dp"
+                    app:cardElevation="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:background="?attr/colorSurfaceContainer"
+                        android:padding="16dp">
+
+                        <!-- 大标题：杜比 -->
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/NativePermissionController_Title"
+                            android:textSize="18sp"
+                            android:textStyle="bold"
+                            android:textColor="?attr/colorOnSurface"
+                            android:layout_marginBottom="16dp" />
+
+                        <!-- Dolby选项 - 整个项目可点击，带有涟漪效果 -->
+                        <LinearLayout
+                            android:id="@+id/NativePermissionControllerLinearLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center_vertical"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true">
+
+                            <LinearLayout
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/NativePermissionController_enable_title"
+                                    android:textSize="16sp"
+                                    android:textColor="?attr/colorOnSurface" />
+
+                                <TextView
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/NativePermissionController_enable_summary"
+                                    android:textSize="12sp"
+                                    android:textColor="?attr/colorOnSurfaceVariant"
+                                    android:layout_marginTop="4dp" />
+
+                            </LinearLayout>
+
+                            <!-- 允许关闭杜比 -->
+                            <com.google.android.material.materialswitch.MaterialSwitch
+                                android:id="@+id/switch_AllowNativePermissionController"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+
+                        </LinearLayout>
+
+
 
                     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,7 @@
     <string name="Dolby_Title">杜比音效</string>
     <string name="AllowDisableDolby">允许关闭杜比</string>
     <string name="AllowDisableDolby_summary">允许关闭杜比全景声，但是可能导致音量变小</string>
+    <string name="NativePermissionController_Title">权限控制器</string>
+    <string name="NativePermissionController_enable_title">原生权限控制器样式</string>
+    <string name="NativePermissionController_enable_summary">启用原生风格的权限控制器</string>
 </resources>


### PR DESCRIPTION
在“设置”子页面下添加了“使用原生权限控制器”的开关，当开关启用时，com.android.settings中“应用管理”->“权限管理”页面将不使用ZUXOS样式，而是使用Android原生UI，UI改动和Hook效果的详情可以参考下列图片

<img width="3200" height="2000" alt="Screenshot_20251112-120431" src="https://github.com/user-attachments/assets/32793059-75e4-48bb-a799-2bb53caee0e9" />
图1 现在的ZTool "设置"子项页面

<img width="3200" height="2000" alt="Screenshot_20251112-115656" src="https://github.com/user-attachments/assets/20204e9b-4fac-4d8b-9ad7-d54248970695" />
图2 初始的权限管理器页面

<img width="3200" height="2000" alt="Screenshot_20251112-115639" src="https://github.com/user-attachments/assets/0f0f4f5d-7eb6-41f3-bb81-ff5d243d6843" />
图3 Hook后的权限管理器页面